### PR TITLE
Lazy load AWS provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.serverless
+serverless.yml
+
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 1.0.1 (2019/03/11)
+* Lazy load `AWS` provider to fix deployment errors when using `ssm` variables.

--- a/index.js
+++ b/index.js
@@ -40,7 +40,15 @@ class ServerlessSESConfigurationSetSNSDestination {
         this.serverless = serverless;
         this.options = options;
 
-        this.hooks = {
+        if (!serverless.service.custom.snsDestination) {
+            this.serverless.cli.log(`Missing configuration for plugin serverless-ses-sns`);
+        } else {
+            this.hooks = this.setupHooks();
+        }
+    }
+
+    setupHooks() {
+        return {
             'after:deploy:deploy': () => makeCreateHook(this.serverless)(this.serverless.service),
             'before:remove:remove': () => makeRemoveHook(this.serverless)(this.serverless.service)
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-ses-sns",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-ses-sns",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Serverless plugin to add a SNS destination to a SES ConfigurationSet",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
This PR fixes deployments using `${ssm:}` variable in the provider section of `serverless.yml`. https://github.com/serverless/serverless/issues/4311